### PR TITLE
Fix grouping not supported error

### DIFF
--- a/background.js
+++ b/background.js
@@ -23,7 +23,10 @@ async function updateAll() {
     currentWindow: true,
     discarded: false,
   });
-  const collapsedTabGroups = await chrome.tabGroups.query({ collapsed: true });
+  const collapsedTabGroups = await chrome.tabGroups.query({
+    windowId: chrome.windows.WINDOW_ID_CURRENT,
+    collapsed: true,
+  });
   const collapsedTabGroupIds = new Set(
     collapsedTabGroups.map((tabGroup) => tabGroup.id)
   );


### PR DESCRIPTION
Sometimes an error `Uncaught (in promise) Error: Grouping is not supported by tabs in this window.` occurs unless `windowId` of `chrome.tabGroups.query()` is specified.