### PR TITLE
Fix a conflict with some sites' notifications count

### DIFF
--- a/background.js
+++ b/background.js
@@ -66,7 +66,7 @@ function updateOne(number) {
     return;
   }
 
-  const TITLE_PATTERN = /^\d+\. /;
+  const TITLE_PATTERN = /^\d+\. (?:\(\d+\) \d+\. )?/;
   const unnumberedTitle = document.title.replace(TITLE_PATTERN, "");
 
   cache.number = number;


### PR DESCRIPTION
Some sites use a title like "(1) something"; the "(1)" means there is a notification. chrome-show-tab-numbers has conflicted with the notifications count and has built a title like "2. (1) 2. something."