### PR TITLE
Improve release process

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,12 @@
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+changelog:
+  categories:
+    - title: New Features / Improvements 🎉
+      labels:
+        - enhancement
+    - title: Bug Fixes 🛠
+      labels:
+        - bug
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,20 @@
+on:
+  push:
+    tags:
+      - "*"
+
+name: Create a Release
+
+jobs:
+  create-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Create release
+        run: >-
+          latest_tag="$(git describe --tags --abbrev=0)";
+          gh release create "${latest_tag}" --generate-notes;
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    timeout-minutes: 5

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 .DEFAULT_GOAL := help
 HELP_SEPARATOR := ＠
 
-package_name := chrome-show-tab-numbers
-package_targets := manifest.json background.js assets/icon128.png
+PACKAGE_NAME := chrome-show-tab-numbers
+PACKAGE_TARGETS := manifest.json background.js assets/icon128.png
 
 EXTRACT_VERSION := jq --raw-output .version
 
@@ -35,6 +35,6 @@ update-version:  ## Update version
 
 .PHONY: zip
 zip:  ## Build a zip file for upload
-	rm -f packages/$(package_name).zip
-	zip packages/$(package_name) $(package_targets)
+	rm -f packages/$(PACKAGE_NAME).zip
+	zip packages/$(PACKAGE_NAME) $(PACKAGE_TARGETS)
 	open packages

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,6 @@ HELP_SEPARATOR := ＠
 PACKAGE_NAME := chrome-show-tab-numbers
 PACKAGE_TARGETS := manifest.json background.js assets/icon128.png
 
-EXTRACT_VERSION := jq --raw-output .version
-
 .PHONY: help
 help:  ## Show help
 	@cat $(MAKEFILE_LIST) | \
@@ -21,17 +19,17 @@ lint:  ## Lint files
 fix:  ## Format files
 	npm run fix
 
-.PHONY: update-version
-update-version:  ## Update version
-	$${EDITOR} ./manifest.json ./package.json
-	[ "$$(cat manifest.json | ${EXTRACT_VERSION})" = "$$(cat package.json | ${EXTRACT_VERSION})" ] || \
-		(echo "ERROR - version mismatch in manifest.json and package.json" && exit 1)
-	npm install
-	git add --patch -- manifest.json package.json package-lock.json
-	git commit --message "Bump up version"
-	git tag "v$$(cat manifest.json | ${EXTRACT_VERSION})"
-	git push --tags
-	git push
+.PHONY: update-major
+update-major:  ## Update the major version
+	scripts/update-version major
+
+.PHONY: update-minor
+update-minor:  ## Update the minor version
+	scripts/update-version minor
+
+.PHONY: update-patch
+update-patch:  ## Update the patch version
+	scripts/update-version patch
 
 .PHONY: zip
 zip:  ## Build a zip file for upload

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,28 @@
+.DEFAULT_GOAL := help
+HELP_SEPARATOR := ＠
+
 package_name := chrome-show-tab-numbers
 package_targets := manifest.json background.js assets/icon128.png
 
 EXTRACT_VERSION := jq --raw-output .version
 
+.PHONY: help
+help:  ## Show help
+	@cat $(MAKEFILE_LIST) | \
+		grep -E '^[-a-z]+:.*##' | \
+		sed -e 's/:.*## /$(HELP_SEPARATOR)/' | \
+		column -t -s $(HELP_SEPARATOR)
+
 .PHONY: lint
-lint:
+lint:  ## Lint files
 	npm run lint
 
 .PHONY: fix
-fix:
+fix:  ## Format files
 	npm run fix
 
 .PHONY: update-version
-update-version:
+update-version:  ## Update version
 	$${EDITOR} ./manifest.json ./package.json
 	[ "$$(cat manifest.json | ${EXTRACT_VERSION})" = "$$(cat package.json | ${EXTRACT_VERSION})" ] || \
 		(echo "ERROR - version mismatch in manifest.json and package.json" && exit 1)
@@ -24,7 +34,7 @@ update-version:
 	git push
 
 .PHONY: zip
-zip:
+zip:  ## Build a zip file for upload
 	rm -f packages/$(package_name).zip
 	zip packages/$(package_name) $(package_targets)
 	open packages

--- a/README.md
+++ b/README.md
@@ -44,6 +44,6 @@ How to Develop
 How to Release
 --------------------------------------------------
 
-1. Update the version: `make update-version`
+1. Update the version: `make update-major`, `make update-minor`, or `make update-patch`
 1. Execute `make zip`
 1. Upload the built zip file to [Chrome Web Store](https://chrome.google.com/webstore/devconsole) and publish it

--- a/README.md
+++ b/README.md
@@ -45,5 +45,6 @@ How to Release
 --------------------------------------------------
 
 1. Update the version: `make update-major`, `make update-minor`, or `make update-patch`
+   * Check a new release and its release notes on [Releases](/kg8m/chrome-show-tab-numbers/releases)
 1. Execute `make zip`
 1. Upload the built zip file to [Chrome Web Store](https://chrome.google.com/webstore/devconsole) and publish it

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "lint": "eslint .*.js *.js",
-    "fix": "eslint --fix .*.js *.js && prettier --write .*.js *.js"
+    "fix": "eslint --fix .*.js *.js && prettier --write .*.js *.js manifest.json package.json"
   },
   "repository": {
     "type": "git",

--- a/scripts/update-version
+++ b/scripts/update-version
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+function fail {
+  local message="${1:?}"
+  echo "ERROR - ${message}" >&2
+  exit 1
+}
+
+function check_version_consistency {
+  local manifest_version="$(extract_version manifest.json)"
+  local package_version="$(extract_version package.json)"
+
+  if [ ! "${manifest_version}" = "${package_version}" ]; then
+    fail "version mismatch in manifest.json and package.json"
+  fi
+}
+
+function extract_version {
+  local json_filepath="${1:?}"
+  jq --raw-output .version < "${json_filepath}"
+}
+
+git switch main
+git pull
+
+current_version="$(git describe --tags --abbrev=0 | grep -E '\d+\.\d+\.\d+$' -o)"
+IFS=. read -ra current_version_parts <<< "${current_version}"
+current_major="${current_version_parts[0]}"
+current_minor="${current_version_parts[1]}"
+current_patch="${current_version_parts[2]}"
+
+[ -n "${current_major}" ] || fail "current major version is missing"
+[ -n "${current_minor}" ] || fail "current minor version is missing"
+[ -n "${current_patch}" ] || fail "current patch version is missing"
+
+case "${1:?}" in
+  major)
+    next_version="$((current_major + 1)).0.0"
+    ;;
+  minor)
+    next_version="${current_major}.$((current_minor + 1)).0"
+    ;;
+  patch)
+    next_version="${current_major}.${current_minor}.$((current_patch + 1))"
+    ;;
+  *)
+    echo "Unknown type: $1" >&2
+    exit 1
+    ;;
+esac
+
+check_version_consistency
+sed -ie "s/\"version\": \"${current_version}\"/\"version\": \"${next_version}\"/" manifest.json package.json
+check_version_consistency
+
+# Reflect package.json changes to package-lock.json.
+npm install
+
+# Apply version changes.
+git add --patch -- manifest.json package.json package-lock.json
+git commit --message "Bump up version"
+git push
+
+# Create a new tag.
+git tag "v$(extract_version package-lock.json)"
+git push --tags


### PR DESCRIPTION
* Bump version with `make update-major`, `make update-minor`, or `make update-patch` instead of `make update-version`
* A release is automatically created when a new tag is pushed