### PR TITLE
Fix `sed()` arguments

### DIFF
--- a/scripts/update-version
+++ b/scripts/update-version
@@ -49,7 +49,7 @@ case "${1:?}" in
 esac
 
 check_version_consistency
-sed -ie "s/\"version\": \"${current_version}\"/\"version\": \"${next_version}\"/" manifest.json package.json
+sed -i '' "s/\"version\": \"${current_version}\"/\"version\": \"${next_version}\"/" manifest.json package.json
 check_version_consistency
 
 # Reflect package.json changes to package-lock.json.


### PR DESCRIPTION
`manifest.jsone` and `package.jsone` were unintentionally created.