### PR TITLE
Support extension context menu to toggle tab numbering of all tabs/current tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Chromium extension to show tab numbers.
 Notable features:
 
 * This extension supports Google Chrome's collapsed tab group feature. Tabs belonging to a collapsed tab group are ignored.
-* You can toggle tab numbering for all tabs or current tab via keyboard shortcuts.
+* You can toggle tab numbering for all tabs or current tab via keyboard shortcuts or extension context menu.
 
 How to Install
 --------------------------------------------------

--- a/background.js
+++ b/background.js
@@ -4,6 +4,18 @@ const COMMANDS = {
   "toggle-all-tabs": toggleAllTabs,
   "toggle-current-tab": toggleCurrentTab,
 };
+const CONTEXT_MENU = {
+  "chrome-show-tab-numbers-toggle-all-tabs": {
+    title: "Toggle tab numbering for all tabs",
+    callback: toggleAllTabs,
+  },
+  "chrome-show-tab-numbers-toggle-current-tab": {
+    title: "Toggle tab numbering for current tab",
+    callback: toggleCurrentTab,
+  },
+};
+
+createContextMenu();
 
 chrome.tabGroups.onCreated.addListener(requestToUpdateAll);
 chrome.tabGroups.onMoved.addListener(requestToUpdateAll);
@@ -16,6 +28,7 @@ chrome.tabs.onUpdated.addListener(requestToUpdateAll);
 
 chrome.tabs.onRemoved.addListener(onTabRemoved);
 chrome.commands.onCommand.addListener(onCommand);
+chrome.contextMenus.onClicked.addListener(onMenuClicked);
 
 const VALID_PROTOCOLS = new Set(["https:", "http:"]);
 const INVALID_HOSTNAMES = new Set(["chrome.google.com"]);
@@ -148,4 +161,19 @@ function onTabRemoved(tabId) {
 
 function onCommand(command) {
   COMMANDS[command]();
+}
+
+function createContextMenu() {
+  chrome.contextMenus.removeAll();
+  for (const menuItemId in CONTEXT_MENU) {
+    chrome.contextMenus.create({
+      contexts: ["action"],
+      id: menuItemId,
+      title: CONTEXT_MENU[menuItemId].title,
+    });
+  }
+}
+
+function onMenuClicked(info) {
+  CONTEXT_MENU[info.menuItemId].callback();
 }

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
   "background": {
     "service_worker": "background.js"
   },
-  "permissions": ["scripting", "tabGroups", "tabs"],
+  "permissions": ["contextMenus", "scripting", "tabGroups", "tabs"],
   "host_permissions": ["<all_urls>"],
   "commands": {
     "toggle-all-tabs": {


### PR DESCRIPTION
For people who don't want to remember keyboard shortcuts.