### PR TITLE
Add pdf support

### DIFF
--- a/background.js
+++ b/background.js
@@ -165,7 +165,7 @@ function updateOne({ isEnabled, number, tabName }) {
   const isCacheAvailable =
     isEnabled === cache.enabled &&
     number === cache.number &&
-    document.title === cache.numberedTitle;
+    tabName === cache.numberedTitle;
 
   if (isCacheAvailable) {
     return;


### PR DESCRIPTION
`chrome.tabs` lets us query the tab name, and returns a value even if `document.title` is blank for a pdf reader tab.

![image](https://github.com/user-attachments/assets/45d0679b-1051-4619-9d8c-50a2a70defda)
